### PR TITLE
Modify scripts to pass dir paths as arguments

### DIFF
--- a/augmented_diff.py
+++ b/augmented_diff.py
@@ -498,7 +498,10 @@ for child in o:
         if nds:
             bounds = Bounds()
             for nd in nds:
-                bounds.add(float(nd.get("lon")), float(nd.get("lat")))
+                lon = nd.get("lon")
+                lat = nd.get("lat")
+                if lon is not None and lat is not None:
+                    bounds.add(float(nd.get("lon")), float(nd.get("lat")))
             osm_obj.insert(0, bounds.elem())
 
 eprint(f"Pass 5: {time.time() - pass_5_start_time:.3f}s")

--- a/gc.sh
+++ b/gc.sh
@@ -6,18 +6,20 @@
 # The openstreetmap.org server automatically closes changesets after 24h,
 # so if a changeset hasn't been modified in at least that long, we can
 # safely assume that it won't change again in the future.
+WORKDIR=/data
+CHANGESET_DIR=$WORKDIR/stage-data/changesets
+SPLIT_ADIFFS=$WORKDIR/stage-data/split-adiffs
 
-find stage-data/changesets/ -type f -mtime +3 -printf '%P\n' \
-  | cut -d '.' -f1 \
-  | while read changeset_id; do
-    echo "removing files for changeset $changeset_id"
-    # atomically move the split files to a temporary location before deleting
-    # them (prevents merge_adiffs.py being run during the deletion, which could
-    # result in an incomplete adiff being generated)
-    tmpdir=$(mktemp -d)
-    mv stage-data/split-adiffs/$changeset_id/ $tmpdir
-    rm -rf $tmpdir
+find "$CHANGESET_DIR" -type f -name "*.adiff.md5" -mtime +3 | while read stampfile; do
+  changeset_id=$(basename "$stampfile" .adiff.md5)
+  echo "removing files for changeset $changeset_id"
+  # atomically move the split files to a temporary location before deleting
+  # them (prevents merge_adiffs.py being run during the deletion, which could
+  # result in an incomplete adiff being generated)
+  tmpdir=$(mktemp -d)
+  mv $SPLIT_ADIFFS/$changeset_id/ $tmpdir
+  rm -rf $tmpdir
 
-    # also delete the stamp file
-    rm stage-data/changesets/$changeset_id.adiff.md5
+  # also delete the stamp file
+  rm $CHANGESET_DIR//$changeset_id.adiff.md5
 done

--- a/gc.sh
+++ b/gc.sh
@@ -6,9 +6,10 @@
 # The openstreetmap.org server automatically closes changesets after 24h,
 # so if a changeset hasn't been modified in at least that long, we can
 # safely assume that it won't change again in the future.
-WORKDIR=/data
-CHANGESET_DIR=$WORKDIR/stage-data/changesets
-SPLIT_ADIFFS=$WORKDIR/stage-data/split-adiffs
+
+SPLIT_ADIFFS_DIR=${1:-'stage-data/split-adiffs'}
+CHANGESET_DIR=${2:-'stage-data/changesets'}
+
 
 find "$CHANGESET_DIR" -type f -name "*.adiff.md5" -mtime +3 | while read stampfile; do
   changeset_id=$(basename "$stampfile" .adiff.md5)
@@ -17,9 +18,9 @@ find "$CHANGESET_DIR" -type f -name "*.adiff.md5" -mtime +3 | while read stampfi
   # them (prevents merge_adiffs.py being run during the deletion, which could
   # result in an incomplete adiff being generated)
   tmpdir=$(mktemp -d)
-  mv $SPLIT_ADIFFS/$changeset_id/ $tmpdir
+  mv $SPLIT_ADIFFS_DIR/$changeset_id/ $tmpdir
   rm -rf $tmpdir
 
   # also delete the stamp file
-  rm $CHANGESET_DIR//$changeset_id.adiff.md5
+  rm $CHANGESET_DIR/$changeset_id.adiff.md5
 done

--- a/merge.mk
+++ b/merge.mk
@@ -24,7 +24,7 @@ changesets: $(shell find $(SPLIT_ADIFFS_DIR)/ -mindepth 1 -type d | sed 's|$(SPL
 # bucket-data/changesets/%.adiff: $$(wildcard stage-data/split-adiffs/%/*)
 $(CHANGESET_DIR)/%.adiff.md5: $$(wildcard $(SPLIT_ADIFFS_DIR)/%/*)
 	tmpfile=$$(mktemp)
-	python merge_adiffs.py $^ | xmlstarlet format > $$tmpfile
+	python merge_adiffs.py $^ > $$tmpfile
 	if [ -s $$tmpfile ]; then
 		# merge_adiffs.py can fail if it is given no input files or if one or more
 		# of its input files are not found. Either of these can happen if the input

--- a/merge_adiffs.py
+++ b/merge_adiffs.py
@@ -3,10 +3,18 @@
 Combine multiple augmented diff files into one file. Writes the merged file to stdout.
 
 Usage: merge_adiff.py INPUT_FILE...
+
+Optimized to use streaming XML parsing (lxml iterparse) to minimize memory usage.
 """
 
-import shutil
+import signal
 import sys
+import os.path as path
+
+from lxml import etree as ET
+
+# Handle broken pipe gracefully (e.g., when piped to head or gzip fails)
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 input_files = sys.argv[1:]
 
@@ -14,56 +22,48 @@ if not input_files:
     print("Error: no input files to merge", file=sys.stderr)
     exit(2)
 
-# TODO: this would hugely benefit from a happy-path optimization
-# that simply copies the input file to the output path if there's
-# only one input. That case will be true for the huge majority of
-# changesets and avoids having to parse and re-serialize the XML.
+# Separate metadata file from adiff files
+metadata_file = None
+adiff_files = []
 
-# Here's a stab at it (untested):
-# if len(input_files) == 1:
-#     with open(input_files[0]) as f:
-#         shutil.copyfileobj(f, sys.stdout)
-#     exit(0)
-
-# Oops, wait, now that we're also embedding the changeset metadata
-# into the adiff, we can't use the above shortcut.
-
-from collections import defaultdict
-import os.path as path
-import xml.etree.ElementTree as ET
-
-changeset = None
-actions = []
 for file in input_files:
     if path.basename(file) == "metadata.xml":
-        metadata = ET.parse(file).getroot()
-        changeset = metadata[0]
+        metadata_file = file
     else:
-        adiff = ET.parse(file).getroot()
-        for elem in adiff:
-            if elem.tag != "action":
-                continue
-            actions.append(elem)
+        adiff_files.append(file)
 
-# build output file
-tree = ET.ElementTree()
-root = ET.Element("osm")
+# Write XML header
+sys.stdout.buffer.write(b'<?xml version="1.0" encoding="UTF-8"?>\n')
+sys.stdout.buffer.write(b'<osm version="0.6" generator="osmcha" ')
+sys.stdout.buffer.write(b'copyright="OpenStreetMap and contributors" ')
+sys.stdout.buffer.write(b'attribution="https://www.openhistoricalmap.org/copyright" ')
+sys.stdout.buffer.write(b'license="https://creativecommons.org/publicdomain/zero/1.0/">\n')
 
-root.set("version", "0.6")
-root.set("generator", "osmcha")
-root.set("copyright", "OpenStreetMap and contributors")
-root.set("attribution", "http://www.openstreetmap.org/copyright")
-root.set("license", "http://opendatacommons.org/licenses/odbl/1-0/")
+# Write changeset metadata if present (usually small, safe to parse fully)
+if metadata_file:
+    try:
+        metadata = ET.parse(metadata_file).getroot()
+        changeset = metadata[0]
+        sys.stdout.buffer.write(ET.tostring(changeset, encoding="utf-8"))
+        sys.stdout.buffer.write(b"\n")
+        del metadata, changeset
+    except Exception as e:
+        print(f"Warning: failed to parse metadata file: {e}", file=sys.stderr)
 
-if changeset:
-    root.append(changeset)
+# Stream actions from each adiff file
+for adiff_file in adiff_files:
+    try:
+        context = ET.iterparse(adiff_file, events=("end",), tag="action")
+        for _, action in context:
+            sys.stdout.buffer.write(ET.tostring(action, encoding="utf-8"))
+            sys.stdout.buffer.write(b"\n")
+            # Clear element AND remove from parent to free memory completely
+            action.clear()
+            while action.getprevious() is not None:
+                del action.getparent()[0]
+        del context
+    except Exception as e:
+        print(f"Warning: failed to parse adiff file {adiff_file}: {e}", file=sys.stderr)
 
-for action in actions:
-    root.append(action)
-
-tree._setroot(root)
-
-tree.write(sys.stdout.buffer, encoding="utf-8", xml_declaration=True)
-sys.stdout.write('\n')
-    
-
+# Close the root element
+sys.stdout.buffer.write(b"</osm>\n")

--- a/process.sh
+++ b/process.sh
@@ -11,19 +11,38 @@
 # works (the scripts are installed into /mnt/osmcha/bin). In your own deployment you
 # should ensure that the scripts (specifically split_adiff.py, merge_adiff.py, and
 # merge.mk) are in your $PATH, because process.sh assumes they are.
-export PATH=$PATH:/mnt/osmcha/bin
 
-for adiff_file in $(find stage-data/replication-adiffs/ -type f); do
+# export PATH=$PATH:/mnt/osmcha/bin # Is this really necesary, seems not
+WORKDIR=/data
+REPLICATION_ADIFFS=$WORKDIR/stage-data/replication-adiffs # make sure this same as in ./update.sh
+SPLIT_ADIFFS=$WORKDIR/stage-data/split-adiffs
+CHANGESET_DIR=$WORKDIR/stage-data/changesets
+BUCKET_DIR=$WORKDIR/bucket-data/changesets
+API_URL=${API_URL:-https://api.openstreetmap.org}
+
+
+mkdir -p $SPLIT_ADIFFS $CHANGESET_DIR $BUCKET_DIR
+
+for adiff_file in $(find $REPLICATION_ADIFFS/ -type f); do
   seqno=$(basename -s .adiff $adiff_file)
   tmpdir=$(mktemp -d)
 
   # split the adiff file
-  split_adiff.py $adiff_file $tmpdir
+  python split_adiff.py $adiff_file $tmpdir
+
+  # Check if adiff files  are been generated
+  if [ -z "$(ls -A "$tmpdir"/*.adiff 2>/dev/null)" ]; then
+    echo "No .adiff files generated from $adiff_file — skipping"
+    rm -rf "$tmpdir"
+    continue
+  fi
 
   for file in $tmpdir/*.adiff; do
     changeset=$(basename -s .adiff $file)
-    mkdir -p stage-data/split-adiffs/$changeset/
-    mv $file stage-data/split-adiffs/$changeset/$seqno.adiff
+    echo "Changeset $changeset has $seqno adiffs"
+    # move the adiff file into place
+    mkdir -p $$SPLIT_ADIFFS/$changeset/
+    mv $file $$SPLIT_ADIFFS/$changeset/$seqno.adiff
   done
 
   rm -rf $tmpdir
@@ -39,10 +58,10 @@ for adiff_file in $(find stage-data/replication-adiffs/ -type f); do
   rm $adiff_file
 done
 
-# merge all our split files, potentially updating existing changesets.
-# this is done using a makefile script in order to avoid needlessly reprocessing
-# changesets whose set of input (split-adiffs/) files haven't changed.
-merge.mk
-
-# clean up old stage-data that we don't need anymore
-gc.sh
+# # merge all our split files, potentially updating existing changesets.
+# # this is done using a makefile script in order to avoid needlessly reprocessing
+# # changesets whose set of input (split-adiffs/) files haven't changed.
+# merge.mk
+make -f merge.mk API_URL="$API_URL"
+# # clean up old stage-data that we don't need anymore
+./gc.sh

--- a/process.sh
+++ b/process.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Usage: process.sh
+# Usage: process.sh [replication_dir] [split_dir] [changeset_dir] [bucket_dir] [api_url] [minutes_filter]
 # 
 # Does the following:
 # - splits all adiffs in stage-data/replication-adiffs/*.adiff into stage-data/split-adiffs/*/
@@ -13,17 +13,26 @@
 # merge.mk) are in your $PATH, because process.sh assumes they are.
 
 # export PATH=$PATH:/mnt/osmcha/bin # Is this really necesary, seems not
-WORKDIR=/data
-REPLICATION_ADIFFS=$WORKDIR/stage-data/replication-adiffs # make sure this same as in ./update.sh
-SPLIT_ADIFFS=$WORKDIR/stage-data/split-adiffs
-CHANGESET_DIR=$WORKDIR/stage-data/changesets
-BUCKET_DIR=$WORKDIR/bucket-data/changesets
-API_URL=${API_URL:-https://api.openstreetmap.org}
+
+REPLICATION_ADIFFS_DIR=${1:-'stage-data/replication-adiffs'}
+SPLIT_ADIFFS_DIR=${2:-'stage-data/split-adiffs'}
+CHANGESET_DIR=${3:-'stage-data/changesets'}
+BUCKET_DIR=${4:-'bucket-data/replication/minute'}
+API_URL=${5:-'https://api.openstreetmap.org'}
+FILTER_ADIFF_FILES=${6:-''}
 
 
-mkdir -p $SPLIT_ADIFFS $CHANGESET_DIR $BUCKET_DIR
+# Determine which .adiff files to process
+if [ -n "$FILTER_ADIFF_FILES" ]; then
+  echo "Filtering .adiff files modified in the last $FILTER_ADIFF_FILES minutes..."
+  adiff_files=$(find "$REPLICATION_ADIFFS_DIR" -type f -mmin -"$FILTER_ADIFF_FILES")
+else
+  echo "Processing all .adiff files in $REPLICATION_ADIFFS_DIR..."
+  adiff_files=$(find "$REPLICATION_ADIFFS_DIR" -type f)
+fi
 
-for adiff_file in $(find $REPLICATION_ADIFFS/ -type f); do
+for adiff_file in $adiff_files; do
+
   seqno=$(basename -s .adiff $adiff_file)
   tmpdir=$(mktemp -d)
 
@@ -41,8 +50,8 @@ for adiff_file in $(find $REPLICATION_ADIFFS/ -type f); do
     changeset=$(basename -s .adiff $file)
     echo "Changeset $changeset has $seqno adiffs"
     # move the adiff file into place
-    mkdir -p $$SPLIT_ADIFFS/$changeset/
-    mv $file $$SPLIT_ADIFFS/$changeset/$seqno.adiff
+    mkdir -p $SPLIT_ADIFFS_DIR/$changeset/
+    mv $file $SPLIT_ADIFFS_DIR/$changeset/$seqno.adiff
   done
 
   rm -rf $tmpdir
@@ -62,6 +71,12 @@ done
 # # this is done using a makefile script in order to avoid needlessly reprocessing
 # # changesets whose set of input (split-adiffs/) files haven't changed.
 # merge.mk
-make -f merge.mk API_URL="$API_URL"
+make -f merge.mk \
+  REPLICATION_ADIFFS_DIR="${REPLICATION_ADIFFS_DIR}" \
+  SPLIT_ADIFFS_DIR="${SPLIT_ADIFFS_DIR}" \
+  CHANGESET_DIR="${CHANGESET_DIR}" \
+  BUCKET_DIR="${BUCKET_DIR}" \
+  API_URL="${API_URL}"
+
 # # clean up old stage-data that we don't need anymore
-./gc.sh
+./gc.sh "${SPLIT_ADIFFS_DIR}" "${CHANGESET_DIR}"

--- a/update.sh
+++ b/update.sh
@@ -16,7 +16,13 @@ export PATH=$PATH:/${PWD}
 
 eval "$(mise activate bash --shims)"
 
-osm replication minute --seqno $(osmx query $1 seqnum) \
+if [ -n "$INITIAL_SEQNUM" ]; then
+  seqno_start="$INITIAL_SEQNUM"
+else
+  seqno_start="$(osmx query "$1" seqnum)"
+fi
+
+osm replication minute --seqno $seqno_start \
   | while read seqno timestamp url; do
   test -z "$seqno" && continue # skip blank lines or empty output
 

--- a/update.sh
+++ b/update.sh
@@ -12,7 +12,7 @@
 # to use flock to ensure that only one instance of the job is running at a time.
 
 set -ex
-export PATH=$PATH:/home/osmx/osmx-adiff-builder
+export PATH=$PATH:/${PWD}
 
 eval "$(mise activate bash --shims)"
 

--- a/update.sh
+++ b/update.sh
@@ -11,17 +11,13 @@
 # should run this script in a cron job once per minute. It is good practice
 # to use flock to ensure that only one instance of the job is running at a time.
 
-set -ex
+set -e
 export PATH=$PATH:/${PWD}
 
-WORKDIR=/data
-DEFAULT_OSMX_DB_PATH=$WORKDIR/db/osmx.db
-DEFAULT_REPLICATION_ADIFFS=$WORKDIR/stage-data/replication-adiffs
-
-## Use $1 or s2 if passed, else default
-OSMX_DB_PATH="${1:-$DEFAULT_OSMX_DB_PATH}"
-REPLICATION_ADIFFS="${2:-$DEFAULT_REPLICATION_ADIFFS}"
-mkdir -p $REPLICATION_ADIFFS
+## Initial sequence number — this is only required at the beginning. right after the osmx database is created
+OSMX_DB_PATH=$1
+REPLICATION_ADIFFS_DIR=$2
+INITIAL_SEQNUM=$3
 
 eval "$(mise activate bash --shims)"
 
@@ -39,7 +35,7 @@ osm replication minute --seqno $seqno_start \
   tmpfile=$(mktemp)
 
   augmented_diff.py $OSMX_DB_PATH $seqno.osc | xmlstarlet format > $tmpfile
-  mv $tmpfile $REPLICATION_ADIFFS/$seqno.adiff
+  mv $tmpfile $REPLICATION_ADIFFS_DIR/$seqno.adiff
 
   osmx update $OSMX_DB_PATH $seqno.osc $seqno $timestamp --commit
   rm $seqno.osc


### PR DESCRIPTION
I’ve modified a few points in the scripts, mainly related to path handling. Currently, the scripts are running in a container. https://github.com/OpenHistoricalMap/ohm-deploy/tree/ohmexpress/images/ohmx-adiff-builder.

I created a bash script https://github.com/OpenHistoricalMap/ohm-deploy/blob/ohmexpress/images/ohmx-adiff-builder/start.sh where I centralize all the required directories, and from there I call the update.sh and process.sh scripts as well and run every minute. 

In addition, I’ve added an INITIAL_SEQNUM argument to update.sh, which allows starting from a specific sequence number. This is needed because when I create my OSMX database for OHM, it initially doesn’t have a sequence set, so it’s necessary to define an initial sequence — usually a few hours before the planet dump was created. that works fine.

Perhaps these changes won’t be adopted, or maybe they could be useful in the future when we can add a Docker container  to run the scripts more automatically.